### PR TITLE
Hide Emacs modeline

### DIFF
--- a/CONTAINERS.org
+++ b/CONTAINERS.org
@@ -1,4 +1,4 @@
--*- mode: org; coding: utf-8; -*-
+# -*- mode: org; coding: utf-8; -*-
 
 #+TITLE: GNU Guix containers
 

--- a/DISTRIBUTE.org
+++ b/DISTRIBUTE.org
@@ -1,4 +1,4 @@
--*- mode: org; coding: utf-8; -*-
+# -*- mode: org; coding: utf-8; -*-
 
 #+TITLE: Distribute software with GNU Guix
 

--- a/TROUBLESHOOTING.org
+++ b/TROUBLESHOOTING.org
@@ -1,4 +1,4 @@
--*- mode: org; coding: utf-8; -*-
+# -*- mode: org; coding: utf-8; -*-
 
 #+TITLE: Troubleshooting GNU Guix
 


### PR DESCRIPTION
This PR hides the Emacs modeline, otherwise it is visible in exports.